### PR TITLE
Update Honda-CR-V-Hybrid generations: Added references and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Honda CR-V Hybrid
 
+This repository contains signal set configurations for the Honda CR-V Hybrid, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Honda CR-V Hybrid.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,8 @@
+references:
+  - "https://en.wikipedia.org/wiki/Honda_CR-V"
+  - "https://en.wikipedia.org/wiki/Honda_CR-V_(fifth_generation)"
+  - "https://en.wikipedia.org/wiki/Honda_CR-V_(sixth_generation)"
+
 generations:
   - name: "First Generation (Fifth-generation CR-V platform)"
     start_year: 2017


### PR DESCRIPTION
- Added Wikipedia reference URLs from main CR-V, 5th gen, and 6th gen articles
- Verified generation data against Wikipedia infoboxes:
  * Fifth-gen (2017-2022): Hybrid introduced for North America in 2020 model year
  * Sixth-gen (2023-present): Hybrid available from model's September 2022 launch
- Updated README.md with standard template

Wikipedia evidence:
- Fifth-gen: "For the first time in North America, the refreshed model introduced a hybrid powertrain as an option" (2020 MY)
- Sixth-gen: "The e:HEV/Hybrid was available since the model's introduction" (Sept 2022)
